### PR TITLE
this pull request would update more dependencies than necessary, but do read the description for the minimum and you might cherry-pick those commits

### DIFF
--- a/.pyup.yml
+++ b/.pyup.yml
@@ -1,0 +1,21 @@
+# update schedule
+# default: empty
+# allowed: "every day", "every week", ..
+schedule: "every day"
+
+# search for requirement files
+# default: True
+# allowed: True, False
+search: False
+
+# Specify requirement files by hand, default is empty
+# default: empty
+# allowed: list
+requirements:
+  - requirements.pip:
+      # update all dependencies and pin them
+      update: all
+      pin: True
+  - requirements-dev.pip:
+      # don't update dependencies, use global 'pin' default
+      update: False

--- a/README.rst
+++ b/README.rst
@@ -9,17 +9,17 @@ Nano (RaiBlocks) Python Library
     :target: https://travis-ci.org/dourvaris/nano-python
 
 .. image:: https://readthedocs.org/projects/nano-python/badge/?version=latest
-    :target: http://nano-python.readthedocs.io/en/latest/?badge=latest
+    :target: https://nano-python.readthedocs.io/en/latest/?badge=latest
     :alt: Documentation Status
 
 .. image:: https://github.com/dourvaris/nano-python/raw/master/coverage.svg?sanitize=true
     :target: https://travis-ci.org/dourvaris/nano-python
 
 .. image:: https://img.shields.io/pypi/pyversions/nano-python.svg?style=flat-square
-    :target: https://pypi.python.org/pypi/nano-python
+    :target: https://pypi.org/project/nano-python/
 
 .. image:: https://img.shields.io/pypi/v/nano-python.svg
-    :target: https://pypi.python.org/pypi/nano-python
+    :target: https://pypi.org/project/nano-python/
 
 This library contains a python wrapper for the Nano (RaiBlocks) RPC server
 which tries to make it a little easier to work with by converting RPC responses

--- a/README.rst
+++ b/README.rst
@@ -63,8 +63,9 @@ for examples of usage.
     >>> rpc.version()
     {
         'rpc_version': 1,
-        'store_version': 10,
-        'node_vendor': 'RaiBlocks 9.0'
+        'store_version': 13,
+        'protocol_version': 16,
+        'node_vendor': 'Nano 18.0'
     }
     >>> rpc.peers()
     {

--- a/README.rst
+++ b/README.rst
@@ -77,6 +77,7 @@ Crypto/Accounts
 ===============
 
 .. code-block:: python
+
     >>> from nano import generate_account, verify_signature, sign_message
     >>> account = generate_account(seed='someseed')
     >>> signature = sign_message(b'this', account['private_key_bytes'])

--- a/docs/make.bat
+++ b/docs/make.bat
@@ -1,0 +1,35 @@
+@ECHO OFF
+
+pushd %~dp0
+
+REM Command file for Sphinx documentation
+
+if "%SPHINXBUILD%" == "" (
+	set SPHINXBUILD=sphinx-build
+)
+set SOURCEDIR=.
+set BUILDDIR=_build
+
+if "%1" == "" goto help
+
+%SPHINXBUILD% >NUL 2>NUL
+if errorlevel 9009 (
+	echo.
+	echo.The 'sphinx-build' command was not found. Make sure you have Sphinx
+	echo.installed, then set the SPHINXBUILD environment variable to point
+	echo.to the full path of the 'sphinx-build' executable. Alternatively you
+	echo.may add the Sphinx directory to PATH.
+	echo.
+	echo.If you don't have Sphinx installed, grab it from
+	echo.http://sphinx-doc.org/
+	exit /b 1
+)
+
+%SPHINXBUILD% -M %1 %SOURCEDIR% %BUILDDIR% %SPHINXOPTS%
+goto end
+
+:help
+%SPHINXBUILD% -M help %SOURCEDIR% %BUILDDIR% %SPHINXOPTS%
+
+:end
+popd

--- a/docs/rpc/methods/node.rst
+++ b/docs/rpc/methods/node.rst
@@ -308,6 +308,7 @@ Returns the node's RPC version
    >>> rpc.version()
    {
        "rpc_version": 1,
-       "store_version": 10,
-       "node_vendor": "RaiBlocks 9.0"
+       "store_version": 13,
+       "protocol_version": 16,
+       "node_vendor": "Nano 18.0"
    }

--- a/requirements.pip
+++ b/requirements.pip
@@ -1,4 +1,4 @@
-certifi==2019.3.9
+certifi
 chardet==3.0.4
 idna==2.8
 pyblake2==1.1.2

--- a/requirements.pip
+++ b/requirements.pip
@@ -3,5 +3,5 @@ chardet==3.0.4
 idna==2.6
 pyblake2==1.1.0
 requests==2.18.4
-six==1.11.0
+six==1.12.0
 urllib3==1.22

--- a/requirements.pip
+++ b/requirements.pip
@@ -1,4 +1,4 @@
-certifi==2017.11.5
+certifi==2019.3.9
 chardet==3.0.4
 idna==2.6
 pyblake2==1.1.0

--- a/requirements.pip
+++ b/requirements.pip
@@ -1,7 +1,7 @@
 certifi==2017.11.5
 chardet==3.0.4
 idna==2.6
-pyblake2==1.1.0
+pyblake2==1.1.2
 requests==2.18.4
 six==1.11.0
 urllib3==1.22

--- a/requirements.pip
+++ b/requirements.pip
@@ -1,6 +1,6 @@
 certifi==2017.11.5
 chardet==3.0.4
-idna==2.6
+idna==2.8
 pyblake2==1.1.0
 requests==2.18.4
 six==1.11.0

--- a/requirements.pip
+++ b/requirements.pip
@@ -4,4 +4,4 @@ idna==2.6
 pyblake2==1.1.0
 requests==2.18.4
 six==1.11.0
-urllib3==1.22
+urllib3==1.24.1

--- a/requirements.pip
+++ b/requirements.pip
@@ -2,6 +2,6 @@ certifi==2017.11.5
 chardet==3.0.4
 idna==2.6
 pyblake2==1.1.0
-requests==2.18.4
+requests==2.21.0
 six==1.11.0
 urllib3==1.22

--- a/src/nano/accounts.py
+++ b/src/nano/accounts.py
@@ -13,7 +13,7 @@ Accounts module
 
 """
 
-import random
+import secrets
 from binascii import hexlify, unhexlify
 
 from .crypto import b32xrb_encode, b32xrb_decode, address_checksum, keypair_from_seed
@@ -129,7 +129,7 @@ def generate_account(seed=None, index=0):
     """
 
     if not seed:
-        seed = unhexlify(''.join(random.choice('0123456789ABCDEF') for i in range(64)))
+        seed = unhexlify(''.join(secrets.choice('0123456789ABCDEF') for i in range(64)))
 
     pair = keypair_from_seed(seed, index=index)
     result = {

--- a/src/nano/rpc.py
+++ b/src/nano/rpc.py
@@ -30,8 +30,9 @@ class Client(object):
     >>> rpc.version()
     {
         'rpc_version': 1,
-        'store_version': 10,
-        'node_vendor': 'RaiBlocks 9.0'
+        'store_version': 13,
+        'protocol_version': 16,
+        'node_vendor': 'Nano 18.0'
     }
     """
 
@@ -3356,15 +3357,16 @@ class Client(object):
         >>> rpc.version()
         {
             "rpc_version": 1,
-            "store_version": 10,
-            "node_vendor": "RaiBlocks 9.0"
+            "store_version": 13,
+            "protocol_version": 16,
+            "node_vendor": "Nano 18.0"
         }
 
         """
 
         resp = self.call('version')
 
-        for key in ('rpc_version', 'store_version'):
+        for key in ('rpc_version', 'store_version', 'protocol_version'):
             resp[key] = int(resp[key])
 
         return resp

--- a/tests/fixtures/rpc/version.json
+++ b/tests/fixtures/rpc/version.json
@@ -1,17 +1,19 @@
 [
   {
     "expected": {
-      "node_vendor": "RaiBlocks 9.0",
+      "node_vendor": "Nano 18.0",
+      "protocol_version": 16,
       "rpc_version": 1,
-      "store_version": 10
+      "store_version": 13
     },
     "request": {
       "action": "version"
     },
     "response": {
-      "node_vendor": "RaiBlocks 9.0",
+      "node_vendor": "Nano 18.0",
+      "protocol_version": "16",
       "rpc_version": "1",
-      "store_version": "10"
+      "store_version": "13"
     }
   }
 ]

--- a/tests/test_mock_rpc.py
+++ b/tests/test_mock_rpc.py
@@ -10,8 +10,9 @@ class TestMockRPCSession(object):
         )
         assert resp.json() == {
             "rpc_version": "1",
-            "store_version": "10",
-            "node_vendor": "RaiBlocks 9.0",
+            "store_version": "13",
+            "protocol_version": "16",
+            "node_vendor": "Nano 18.0",
         }
 
     def test_missing_request(self, mock_rpc_session):

--- a/tests/test_rpc.py
+++ b/tests/test_rpc.py
@@ -24,8 +24,9 @@ class TestRPCClient(object):
     def test_call_valid_action(self, rpc):
         assert rpc.call('version') == {
             "rpc_version": "1",
-            "store_version": "10",
-            "node_vendor": "RaiBlocks 9.0",
+            "store_version": "13",
+            "protocol_version": "16",
+            "node_vendor": "Nano 18.0",
         }
 
     def test_call_invalid_action(self, rpc):


### PR DESCRIPTION
urllib3 before 1.23 does not remove the Authorization HTTP header when following a cross-origin redirect (i.e., a redirect that differs in host, port, or scheme). This can allow for credentials in the Authorization header to be exposed to unintended hosts or transmitted in cleartext.

The Requests package before 2.19.1 sends an HTTP Authorization header to an http URI upon receiving a same-hostname https-to-http redirect, which makes it easier for remote attackers to discover credentials by sniffing the network.